### PR TITLE
Save and use access token output, saving some more clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It will return an error page but look at the browser URL bar again. Mendeley wil
 
 Copy the AUTHORIZATION_CODE from the URL.
 
-Then, paste it in to `get-mendeley-token.py` along with your Client_ID and your Client_Secret. Make sure to save the file, then run it (`python get-mendeley-token.py`). Copy the output and save it somewhere as your access token. 
+Then, paste it in to `get-mendeley-token.py` along with your Client_ID and your Client_Secret. Make sure to save the file, then run it (`python get-mendeley-token.py`). This will save a generated access token to a text file to be used automatically by the script in step 5.
 
 ## 3. Extract DOIs from text using ChatGPT
 
@@ -41,10 +41,9 @@ Then, paste it in to `get-mendeley-token.py` along with your Client_ID and your 
 ## 5. Use the script to import DOIs to Mendeley
 
 1. Clone this repository or download the Python script `upload-DOI-to-library.py`.
-2. Open the script in a text editor and replace `YOUR_ACCESS_TOKEN` with your Mendeley access token generated from step 2. 
-3. Update the `dois_file` variable to the path of your text file containing the list of DOIs (if you made it in a different file, also check to make sure it matches the name you gave it).
-4. Run the script from the command line: `python upload-DOI-to-library.py`.
-5. The script will import each document with the available metadata to your Mendeley library. You can open your library in a browser and watch them get added as it syncs; you can also see a list of all the DOIs it added via the command line.
+2. Update the `dois_file` variable to the path of your text file containing the list of DOIs (if you made it in a different file, also check to make sure it matches the name you gave it).
+3. Run the script from the command line: `python upload-DOI-to-library.py`.
+4. The script will use the access token (generated in step 2) to import each document with the available metadata to your Mendeley library. You can open your library in a browser and watch them get added as it syncs; you can also see a list of all the DOIs it added via the command line.
 
 Example output when the script successfully finishes:
 
@@ -53,4 +52,4 @@ Example output when the script successfully finishes:
 
 ## Tips
 
-* You may need to repeat step two to run `get-mendeley-token.py` again and generate an updated access token, and updated it in step 5's script (`upload-DOI-to-library.py`) before running it again if it has been a few hours or more since you last ran the script.
+* You may need to repeat step two to run `get-mendeley-token.py` again and generate an updated access token before running it again if it has been a few hours or more since you last ran the script.

--- a/get-mendeley-token.py
+++ b/get-mendeley-token.py
@@ -13,10 +13,10 @@ data = {
 }
 
 response = requests.post('https://api.mendeley.com/oauth/token', data=data)
-
 if response.status_code == 200:
     access_token = response.json()['access_token']
-    print('Access token:', access_token)
+    with open('access_token.txt', 'w') as file:
+        file.write(access_token)
+    print('Access token saved to access_token.txt')
 else:
     print('Error:', response.status_code, response.text)
-

--- a/upload-DOI-to-library.py
+++ b/upload-DOI-to-library.py
@@ -41,8 +41,12 @@ def create_document(doi, metadata, access_token):
     else:
         print(f'Error creating document with DOI {doi}:', response.status_code, response.text)
 
-# Make sure to replace AUTHORIZATION_CODE with the code you got from Mendeley, and make sure your DOI text file matches the name you gave it.
-access_token = 'AUTHORIZATION_CODE'
+def read_access_token_from_file(filename='access_token.txt'):
+    with open(filename, 'r') as file:
+        return file.read().strip()
+
+# Note that this is reading the token generated from get-mendeley-token.py
+access_token = read_access_token_from_file()
 dois_file = 'dois.txt'
 
 with open(dois_file, 'r') as file:


### PR DESCRIPTION
Switches from copy/pasting the access token generated in the token generation script, which used to be hard coded in the upload DOI script, to saving the token to a text file that is pulled in by the script. 